### PR TITLE
#1 [feat] 스크랩 저장, 삭제 기능 구현 및 공통 코드 추가

### DIFF
--- a/src/main/java/com/example/notifyserver/common/constants/NoticeConstants.java
+++ b/src/main/java/com/example/notifyserver/common/constants/NoticeConstants.java
@@ -1,0 +1,5 @@
+package com.example.notifyserver.common.constants;
+
+public final class NoticeConstants {
+    public static final long PAGE_SIZE = 10; // 한 페이지에 보여줄 공지사항의 개수
+}

--- a/src/main/java/com/example/notifyserver/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/notifyserver/scrap/repository/ScrapRepository.java
@@ -1,6 +1,7 @@
 package com.example.notifyserver.scrap.repository;
 
 import com.example.notifyserver.scrap.domain.Scrap;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,18 +12,18 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
     /**
      * 스크랩을 DB에 저장한다.
-     * @param scrap 스크렙 객체
+     * @param scrap 스크랩 객체
      * @return 저장한 스크랩 객체
      */
     @Override
-    Scrap save(Scrap scrap);
+    Scrap save(@NotNull Scrap scrap);
 
     /**
      * 스크랩을 DB에서 제거한다.
-     * @param entity 제거할 스크랩 객체
+     * @param scrap 제거할 스크랩 객체
      */
     @Override
-    void delete(Scrap entity);
+    void delete(@NotNull Scrap scrap);
 
     /**
      * 페이지에 맞게 스크랩을 DB에서 가져온다.

--- a/src/main/java/com/example/notifyserver/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/example/notifyserver/scrap/repository/ScrapRepository.java
@@ -1,10 +1,14 @@
 package com.example.notifyserver.scrap.repository;
 
+import com.example.notifyserver.common.domain.NoticeType;
 import com.example.notifyserver.scrap.domain.Scrap;
+import feign.Param;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,12 +22,17 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Override
     Scrap save(@NotNull Scrap scrap);
 
+
     /**
      * 스크랩을 DB에서 제거한다.
-     * @param scrap 제거할 스크랩 객체
+     * @param userId 제거할 스크랩의 소유 회원
+     * @param noticeId 제거할 공지사항의 ID
+     * @param type 제거할 공지사항의 종류
      */
-    @Override
-    void delete(@NotNull Scrap scrap);
+
+    @Modifying
+    @Query("DELETE FROM Scrap s WHERE s.user.userId = :userId AND s.notice.noticeId = :noticeId AND s.notice.noticeType = :type")
+    void deleteByUserIdAndNoticeIdAndType(@Param("userId") Long userId, @Param("noticeId") Long noticeId, @Param("type") NoticeType type);
 
     /**
      * 페이지에 맞게 스크랩을 DB에서 가져온다.

--- a/src/main/java/com/example/notifyserver/scrap/service/ScrapService.java
+++ b/src/main/java/com/example/notifyserver/scrap/service/ScrapService.java
@@ -20,9 +20,8 @@ public interface ScrapService {
      * 스크랩 목록에서 해당 스크랩을 제거한다.
      * @param user 스크랩 제거를 요청한 유저
      * @param notice 스크랩에서 제거할 공지사항 객체
-     * @return 제거한 공지사항의 스크랩 ID
      */
-    long deleteScrap(User user, Notice notice);
+    void deleteScrap(User user, Notice notice);
 
     /**
      * 스크랩 목록에서 해당 페이지의 스크랩을 조회한다.

--- a/src/main/java/com/example/notifyserver/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/notifyserver/scrap/service/ScrapServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Service
 public class ScrapServiceImpl implements ScrapService{
 
+    @Autowired
     private ScrapRepository scrapRepository;
 
     /**

--- a/src/main/java/com/example/notifyserver/scrap/service/ScrapServiceImpl.java
+++ b/src/main/java/com/example/notifyserver/scrap/service/ScrapServiceImpl.java
@@ -32,11 +32,13 @@ public class ScrapServiceImpl implements ScrapService{
      * 스크랩 목록에서 해당 스크랩을 제거한다.
      * @param user 스크랩 제거를 요청한 유저
      * @param notice 스크랩에서 제거할 공지사항 객체
-     * @return 제거한 공지사항의 스크랩 ID
      */
     @Override
-    public long deleteScrap(User user, Notice notice) {
-        return 0;
+    public void deleteScrap(User user, Notice notice) {
+        Long userId = user.getUserId();
+        Long noticeId = notice.getNoticeId();
+        NoticeType noticeType = notice.getNoticeType();
+        scrapRepository.deleteByUserIdAndNoticeIdAndType(userId, noticeId, noticeType);
     }
 
     /**

--- a/src/main/java/com/example/notifyserver/user/domain/User.java
+++ b/src/main/java/com/example/notifyserver/user/domain/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/example/notifyserver/scrap/service/ScrapServiceImplTest.java
+++ b/src/test/java/com/example/notifyserver/scrap/service/ScrapServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.example.notifyserver.scrap.service;
+
+import com.example.notifyserver.common.domain.Notice;
+import com.example.notifyserver.common.domain.NoticeType;
+import com.example.notifyserver.scrap.domain.Scrap;
+import com.example.notifyserver.scrap.repository.ScrapRepository;
+import com.example.notifyserver.user.domain.User;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Transactional
+@SpringBootTest
+class ScrapServiceImplTest {
+
+    @Autowired
+    ScrapService scrapService;
+    @Autowired
+    ScrapRepository scrapRepository;
+    @Autowired
+    EntityManager em;
+
+    @Test
+    void doScrap() {
+
+        //given
+        User user = User.builder()
+                .googleId("구글아이디")
+                .nickName("닉네임")
+                .email("이메일")
+                .userMajor("bus")
+                .build();
+
+        Notice notice = Notice.builder()
+                .noticeTitle("공지 제목")
+                .noticeType(NoticeType.COM)
+                .noticeUrl("공지 url")
+                .build();
+
+        //when
+        em.persist(user);
+        em.persist(notice);
+        long findId = scrapService.doScrap(user, notice);
+        Scrap scrappedNotice = scrapRepository.findById(findId).orElse(null);
+
+        //then
+        assert scrappedNotice != null;
+        Assertions.assertThat(scrappedNotice.getScrapId()).isEqualTo(findId);
+    }
+}

--- a/src/test/java/com/example/notifyserver/scrap/service/ScrapServiceImplTest.java
+++ b/src/test/java/com/example/notifyserver/scrap/service/ScrapServiceImplTest.java
@@ -8,9 +8,13 @@ import com.example.notifyserver.user.domain.User;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
 @SpringBootTest
@@ -25,8 +29,22 @@ class ScrapServiceImplTest {
 
     @Test
     void doScrap() {
-
         //given
+        Bundle bundle = getBundle();
+        em.persist(bundle.user());
+        em.persist(bundle.notice());
+
+        //when
+        long findId = scrapService.doScrap(bundle.user(), bundle.notice());
+        Scrap scrappedNotice = scrapRepository.findById(findId).orElse(null);
+
+        //then
+        assert scrappedNotice != null;
+        assertThat(scrappedNotice.getScrapId()).isEqualTo(findId);
+    }
+
+    @NotNull
+    private static Bundle getBundle() {
         User user = User.builder()
                 .googleId("구글아이디")
                 .nickName("닉네임")
@@ -39,15 +57,26 @@ class ScrapServiceImplTest {
                 .noticeType(NoticeType.COM)
                 .noticeUrl("공지 url")
                 .build();
+        Bundle bundle = new Bundle(user, notice);
+        return bundle;
+    }
+
+    private record Bundle(User user, Notice notice) {
+    }
+
+    @Test
+    public void deleteScrap() throws Exception{
+        //given
+        Bundle bundle = getBundle();
+        em.persist(bundle.user());
+        em.persist(bundle.notice());
+        scrapService.doScrap(bundle.user, bundle.notice);
+        int size = scrapRepository.findAll().size();
 
         //when
-        em.persist(user);
-        em.persist(notice);
-        long findId = scrapService.doScrap(user, notice);
-        Scrap scrappedNotice = scrapRepository.findById(findId).orElse(null);
-
+        scrapService.deleteScrap(bundle.user, bundle.notice);
+        
         //then
-        assert scrappedNotice != null;
-        Assertions.assertThat(scrappedNotice.getScrapId()).isEqualTo(findId);
+        assertEquals(size-1, scrapRepository.findAll().size());
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
* #1 

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 2일 / 2일

## 해결하려는 문제가 무엇인가요?
* **공통된 부분에 코드가 추가되어 임시로 PR 합니다.** 
* 스크랩 저장 기능과 스크랩 삭제 기능을 완성하였습니다. 
* 아직 스크랩 조회 기능은 개발 중에 있습니다. 

## 어떻게 해결했나요?
* 공통된 부분에 추가된 코드

1. 공지사항 타입을 문자열에서 사용자 정의 클래스(ENUM)으로 변경하는 코드를 추가하였습니다. 공지사항 타입이 정해져 있으므로 문자열로 다룰 필요가 없다고 판단하였습니다.

2. 한 페이지에 보여줄 공지사항 수를 상수 클래스로 선언하였습니다.