### PR TITLE
#1 [refactor] 스크랩 조회 페이지 번호 수정

### DIFF
--- a/src/main/java/com/example/notifyserver/scrap/controller/ScrapController.java
+++ b/src/main/java/com/example/notifyserver/scrap/controller/ScrapController.java
@@ -91,14 +91,16 @@ public class ScrapController {
 
         User findUser = userRepository.findByGoogleId(googleId)
                 .orElseThrow(() -> new NotFoundUserException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
-        PageRequest pageRequest = PageRequest.of((int) pageNum, (int) NoticeConstants.PAGE_SIZE);
+        // PageRequest에서는 시작이 0부터라서 -1을 실행
+        PageRequest pageRequest = PageRequest.of((int) pageNum-1, (int) NoticeConstants.PAGE_SIZE);
 
         try {
             Page<Scrap> result = scrapService.getScrap(findUser.getUserId(), pageRequest);
             List<Scrap> scrapList = result.getContent();
             GetScrapsResponse response = GetScrapsResponse.builder()
                     .totalPages(result.getTotalPages())
-                    .page(result.getNumber())
+                    // PageRequest에서는 시작이 0부터라서 +1을 실행
+                    .page(result.getNumber()+1)
                     .notices(scrapToNoticeResponse(scrapList))
                     .build();
             return SuccessResponse.success(SuccessCode.GET_SCRAP_SUCCESS,response);


### PR DESCRIPTION
- PageRequest에서는 시작이 0부터라서 페이지 번호를 가져올 때는 -1을 API 응답 시에는 +1을 실행하도록 수정함

## 관련 이슈번호
* Closes #1

## 해결하는 데 얼마나 걸렸나요?  (예상 작업 시간 / 실제 작업 시간)
* 5m / 5m

## 해결하려는 문제가 무엇인가요?
*API에서 사용하는 페이지 시작번호(0)와 외부에서 사용하는 페이지 시작번호(1)이 다릅니다.

## 어떻게 해결했나요?
* 스크랩 컨트롤러에서 페이지 번호를 가져올 때는 -1을 API 응답 시에는 +1을 실행하도록 수정하였습니다.
